### PR TITLE
filter out all SHP trips

### DIFF
--- a/_private/formatListings.inc.php
+++ b/_private/formatListings.inc.php
@@ -65,6 +65,13 @@ function formatListings($groupID, $xslPath, $xslParams = null) {
             die('Sorry, trip information is not available, because the AMC web site trips.outdoors.org could not be contacted. Please try again later. Error: '.htmlspecialchars($e->getMessage()));
         }  
         $xml->loadXML($data);
+        
+        $xpath = new DOMXPath($xml);
+        foreach ($xpath->evaluate("//trip[contains(trip_title, 'SHP')]") as $node) {
+          $node->parentNode->removeChild($node);
+        }
+        $xml->saveXml();
+        
     }
     timeMilestone('Loaded XML data');
     $result = $xsl->transformToXML($xml);

--- a/amc-trips-to-html-inc.xsl
+++ b/amc-trips-to-html-inc.xsl
@@ -158,7 +158,7 @@
         <tr class="section">
           <td colspan="2">All Events by Date</td>
         </tr>
-        <xsl:for-each select="*">
+        <xsl:for-each select="trip[not(contains(trip_title, 'SHP'))]">
           <xsl:sort select="trip_start_date"/>
           <xsl:call-template name="trip-summary-row"/>
         </xsl:for-each>


### PR DESCRIPTION
This is not a real PR, more to show code sample.

Hi @ashearer, i am trying to filter out all the trips whose title contains the word SHP. (Spring Hiking Program). The following filter does work, but it only apply to the "All Events by Date" section, i would like to add similar filter on a more global location, any idea? sorry i am not familiar with xsl at all.

I will create a real PR once Boston HB finalized on what we want.   

the reasoning behind this is because all program hikes will not be open to non program participants so we want to filter out all of it so people dont even see them.